### PR TITLE
Braden

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,2 +1,0 @@
-require('coffee-script/register');
-require('./gulpfile.coffee');

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "davisgig.org",
   "version": "0.0.1",
   "devDependencies": {
+    "coffee-script": "^1.9.2",
     "gulp": "^3.8.6",
     "gulp-coffee": "^2.3.1",
     "gulp-jade": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "gulp": "^3.8.6",
     "gulp-coffee": "^2.3.1",
     "gulp-jade": "^1.0.0",
-    "gulp-livereload": "^2.1.1",
+    "gulp-livereload": "^3.8.0",
     "gulp-sass": "^1.3.3",
     "gulp-util": "^3.0.4",
-    "gulp-watch": "^0.6.9",
+    "gulp-watch": "^4.2.4",
     "main-bower-files": "^2.7.0"
   }
 }


### PR DESCRIPTION
A couple simple changes... one nice thing in particular about updating gulp-livereload is that it no longer gets started up if one just does `gulp build`, which for me meant I had to Ctrl-C gulp to get it to exit (which would have been annoying for scripted deployment).
